### PR TITLE
fix: ape cli context to add -v debug

### DIFF
--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 
 import click
-from ape.cli import NetworkBoundCommand, network_option
+from ape.cli import NetworkBoundCommand, ape_cli_context, network_option
 
 from silverback._importer import import_from_string
 from silverback.runner import LiveRunner
@@ -14,6 +14,7 @@ def cli():
 
 
 @cli.command(cls=NetworkBoundCommand)
+@ape_cli_context
 @network_option()
 @click.option("-x", "--max-exceptions", type=int, default=3)
 @click.argument("path")

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -14,7 +14,7 @@ def cli():
 
 
 @cli.command(cls=NetworkBoundCommand)
-@ape_cli_context
+@ape_cli_context()
 @network_option()
 @click.option("--account", type=AccountAliasPromptChoice(), default=None)
 @click.option("-x", "--max-exceptions", type=int, default=3)


### PR DESCRIPTION
### What I did

adds ape-cli-context in order to let debug verbosity be used

fixes: #6 

### How I did it
added ape_cli_context to click command

### How to verify it
try running with -v DEBUG

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
